### PR TITLE
feat: simplify using emojis.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,5 @@ dist
 .pnp.*
 
 .DS_Store
+
+.vscode

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -41,7 +41,7 @@ tasks:
     cmds:
       - rm -rf dist/
       - rm -rf {{.FUNCTION_ARTIFACT}}
-      - rm -rf src/index.js src/helpers/*.js index.js
+      - rm -rf out/
 
   package:
     desc: Package and zip the application code for deployment
@@ -50,7 +50,7 @@ tasks:
       - task: install
       - task: compile
       - mkdir -p dist
-      - cp -R node_modules src/* package*.json dist
+      - cp -R node_modules out/* package*.json dist
 
   create-slack-token-secret:
     desc: Create a secret in GCP Secret Manager

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,3 @@
-process.env['EMOJIS_FILE_PATH'] = './src/helpers/files/emojis.json';
-
 module.exports = {
     preset: "ts-jest",
     testEnvironment: "node",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "scripts": {
     "start": "functions-framework --target=xplorersbot",
     "test": "task clean && jest --verbose --coverage tests",
-    "start-local-server": "task clean && tsc && cd src && npx functions-framework --target=xplorersbot --signature-type=http"
+    "start-local-server": "task clean && tsc && cd out && npx functions-framework --target=xplorersbot --signature-type=http"
   },
   "dependencies": {
     "@google-cloud/logging": "^10.4.0",

--- a/src/helpers/constants.ts
+++ b/src/helpers/constants.ts
@@ -1,2 +1,1 @@
 export const SUCCESS_MESSAGE: string = 'Successfully processed slack event';
-export const DEFAULT_EMOJIS_FILE_PATH: string = "./helpers/files/emojis.json";

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,7 +26,9 @@ const LOG_METADATA = {
 
 const slackWebClient: SlackWebClient = new WebClient(
     process.env.SLACK_OAUTH_TOKEN ||
-        fs.readFileSync(`/etc/secrets/slack-oauth-token-${process.env.TERRAFORM_WORKSPACE_NAME}`)
+        fs.readFileSync(
+            `/etc/secrets/slack-oauth-token-${process.env.TERRAFORM_WORKSPACE_NAME}`
+        )
 );
 
 // app entry point

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -49,7 +49,7 @@
     // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
     // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
     // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
-    // "outDir": "./",                                   /* Specify an output folder for all emitted files. */
+    "outDir": "out",                                   /* Specify an output folder for all emitted files. */
     // "removeComments": true,                           /* Disable emitting comments. */
     // "noEmit": true,                                   /* Disable emitting files from a compilation. */
     // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */


### PR DESCRIPTION
## Changes

- import emojis.json file directly and use it rather than using `fs` to get file from the path
- when running project locally, `js` files were generated next to `typescript` files always. So, transpiling the `typescript` files to `out` dir