### PR TITLE
feat(xplorers-bot-ts): queue with same name can only be recreated after 7 days

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -100,7 +100,9 @@ resource "google_project_iam_member" "xplorers_bot_function_custom_role_binding"
 }
 
 resource "google_cloud_tasks_queue" "xplorers_bot_queue" {
-  name     = "xplorers-bot-queue-${terraform.workspace}"
+  /* Todo: remove the -tmp in the next Pull Request
+  https://cloud.google.com/tasks/docs/deleting-appengine-queues-and-tasks#deleting_queues*/
+  name     = "xplorers-bot-queue-${terraform.workspace}-tmp"
   project  = var.project_id
   location = var.region
   rate_limits {


### PR DESCRIPTION
### Cloud task queue with the same name can only be recreated after 7 days (of deletion)

![image](https://github.com/xplorer-io/xplorers-bot-ts/assets/42393225/01411285-8a91-49df-8271-4cf3aa0e88db)

### From [GCP docs](https://cloud.google.com/tasks/docs/deleting-appengine-queues-and-tasks#:~:text=If%20you%20delete,periodic%20internal%20processes.)

![image](https://github.com/xplorer-io/xplorers-bot-ts/assets/42393225/3e875a51-b5ff-4f67-8c4e-2d340ddfe6dd)
