### PR TITLE
fix(xplorers-openai): ignore slack post deleted event

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "packages": {
     "": {
       "dependencies": {
-        "@azure/openai": "^1.0.0-beta.2",
-        "@google-cloud/logging": "^10.4.0",
-        "@google-cloud/tasks": "^3.1.2",
+        "@azure/openai": "^1.0.0-beta.3",
+        "@google-cloud/logging": "^10.5.0",
+        "@google-cloud/tasks": "^3.2.0",
         "@slack/web-api": "^6.8.1"
       },
       "devDependencies": {
@@ -896,9 +896,9 @@
       }
     },
     "node_modules/@grpc/grpc-js": {
-      "version": "1.8.20",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.8.20.tgz",
-      "integrity": "sha512-SPse1wE4PcIFojOISsAnrWXCBsCBwDdcDqz2SS0T8nBSxg9jwmCK70Jy7ypRn2nIspwLy3Ls5TNaKNHo+6dF8A==",
+      "version": "1.8.21",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.8.21.tgz",
+      "integrity": "sha512-KeyQeZpxeEBSqFVTi3q2K7PiPXmgBfECc4updA1ejCLjYmoAlvvM3ZMp5ztTDUCUQmoY3CpDxvchjO1+rFkoHg==",
       "dependencies": {
         "@grpc/proto-loader": "^0.7.0",
         "@types/node": ">=12.12.47"
@@ -2412,9 +2412,9 @@
       }
     },
     "node_modules/dedent": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.2.0.tgz",
-      "integrity": "sha512-i4tcg0ClgvMUSxwHpt+NHQ01ZJmAkl6eBvDNrSZG9e+oLRTCSHv0wpr/Bzjpf6CwKeIHGevE1M34Y1Axdms5VQ==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.3.0.tgz",
+      "integrity": "sha512-7glNLfvdsMzZm3FpRY1CHuI2lbYDR+71YmrhmTZjYFD5pfT0ACgnGRdrrC9Mk2uICnzkcdelCx5at787UDGOvg==",
       "dev": true,
       "peerDependencies": {
         "babel-plugin-macros": "^3.1.0"
@@ -2523,9 +2523,9 @@
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.473",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.473.tgz",
-      "integrity": "sha512-aVfC8+440vGfl06l8HKKn8/PD5jRfSnLkTTD65EFvU46igbpQRri1gxSzW9/+TeUlwYzrXk1sw867T96zlyECA==",
+      "version": "1.4.477",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.477.tgz",
+      "integrity": "sha512-shUVy6Eawp33dFBFIoYbIwLHrX0IZ857AlH9ug2o4rvbWmpaCUdBpQ5Zw39HRrfzAFm4APJE9V+E2A/WB0YqJw==",
       "dev": true
     },
     "node_modules/emittery": {
@@ -2636,9 +2636,9 @@
       }
     },
     "node_modules/eslint-visitor-keys": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.1.tgz",
-      "integrity": "sha512-pZnmmLwYzf+kWaM/Qgrvpen51upAktaaiI01nsJD/Yr3lMOdNtq0cxkrrg16w64VtisN6okbs7Q8AfGqj4c9fA==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.2.tgz",
+      "integrity": "sha512-8drBzUEyZ2llkpCA67iYrgEssKDUu68V8ChqqOfFupIaG/LCVPUT+CoGJpT77zJprs4T/W7p07LP7zAIMuweVw==",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -7,9 +7,9 @@
     "start-openai-server": "task clean && tsc && cd out && npx functions-framework --target=xplorersbotOpenAI --signature-type=http"
   },
   "dependencies": {
-    "@azure/openai": "^1.0.0-beta.2",
-    "@google-cloud/logging": "^10.4.0",
-    "@google-cloud/tasks": "^3.1.2",
+    "@azure/openai": "^1.0.0-beta.3",
+    "@google-cloud/logging": "^10.5.0",
+    "@google-cloud/tasks": "^3.2.0",
     "@slack/web-api": "^6.8.1"
   },
   "devDependencies": {

--- a/src/helpers/openai.ts
+++ b/src/helpers/openai.ts
@@ -37,9 +37,6 @@ export async function askOpenAI(message: string) {
             messages
         );
 
-        // json result
-        console.log(JSON.stringify(chatCompletion, null, 2));
-
         return chatCompletion?.choices?.[0]?.message?.content ?? "";
     } catch (err) {
         console.error("Error occured when interacting with OpenAI:", err);

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,8 +43,20 @@ export const xplorersbot: HttpFunction = async (req, res) => {
     switch (req.body.type) {
         case "event_callback":
             const slackEvent = req?.body?.event;
+            const isMessageDeletedEvent =
+                slackEvent?.subtype === "message_deleted";
 
-            if (slackEvent.bot_id) {
+            // if message and previous message are same, its a message deletion event
+            const isMessageChangedDeletedEvent =
+                slackEvent?.message?.text ===
+                slackEvent?.previous_message?.text;
+
+            // if bot event or message deleted event then break
+            if (
+                slackEvent.bot_id ||
+                isMessageDeletedEvent ||
+                isMessageChangedDeletedEvent
+            ) {
                 break;
             }
 


### PR DESCRIPTION
### When a slack post is deleted, slack sends 2 separate - `messaged_deleted` and `message_changed` invocations for the same event. This caused the openai bot to respond to the same event more than once which is not intended. Ignore both message deleted and changed events. 